### PR TITLE
Remove hardcoded API key

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,7 @@ sections:
     widgets:
       - type: weather
         options:
-          apiKey: 8f27148920dd4b18d2d62c2bf83fc0df
+          apiKey: ${WEATHER_API_KEY}
           city: Chapel Hill
           units: imperial
   - name: Service Status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     volumes:
       - ./config.yml:/app/user-data/conf.yml
       - ./item-icons/:/app/user-data/item-icons/
+    env_file:
+      - ./.env
     ports:
       - 8085:8080
     environment:

--- a/example.env
+++ b/example.env
@@ -1,0 +1,3 @@
+# Example environment variables for Dashy
+# Copy this file to .env and set your secrets
+WEATHER_API_KEY=your_openweathermap_api_key


### PR DESCRIPTION
## Summary
- load weather widget API key from environment
- use env file in docker-compose
- provide example.env for weather widget

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c3966dac83298edb4feede7ea28d